### PR TITLE
feat: make Gerrit TLS verification configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ export GERRIT_HOST="gerrit.example.com"  # Your Gerrit server hostname (without 
 export GERRIT_USER="your-username"       # Your Gerrit account username
 export GERRIT_HTTP_PASSWORD="your-http-password"  # Generated HTTP password from Gerrit Settings > HTTP Credentials
 export GERRIT_EXCLUDED_PATTERNS="\.pbxproj$,\.xcworkspace$,node_modules/"  # Optional: regex patterns for files to exclude from reviews
+# Optional TLS configuration for custom or self-signed certificates
+export GERRIT_SSL_VERIFY="true"              # Set to 'false' to skip TLS verification in constrained environments
+export GERRIT_CA_BUNDLE="/path/to/ca.pem"    # Optional custom CA bundle path used when verification stays enabled
+# Note: If both are set, GERRIT_CA_BUNDLE takes precedence and verification stays enabled using that bundle.
 ```
 
 Or create a `.env` file:
@@ -108,6 +112,9 @@ GERRIT_HOST=gerrit.example.com
 GERRIT_USER=your-username
 GERRIT_HTTP_PASSWORD=your-http-password
 GERRIT_EXCLUDED_PATTERNS=\.pbxproj$,\.xcworkspace$,node_modules/
+GERRIT_SSL_VERIFY=true
+GERRIT_CA_BUNDLE=/path/to/ca.pem
+# If both are set, the CA bundle wins.
 ```
 
 2. Generate HTTP password:
@@ -180,6 +187,12 @@ If you encounter connection issues:
 ### HTTP Credentials Authentication Issues
 
 If you're having trouble with authentication, check your Gerrit config for `gitBasicAuthPolicy = HTTP` (or `HTTP_LDAP`).
+
+### Working with Self-Signed Certificates
+
+- `GERRIT_SSL_VERIFY=false` disables TLS verification when Gerrit uses an internally issued certificate lacking required Subject Alternative Name (SAN) entries.
+- Provide a custom certificate bundle via `GERRIT_CA_BUNDLE=/path/to/ca.pem` to keep verification enabled while trusting a private CA.
+- Treat disabled verification as a temporary workaround until a certificate with matching SANs is issued for the Gerrit hostnames you access.
 
 ## License
 

--- a/tests/test_ssl_config.py
+++ b/tests/test_ssl_config.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Unit tests for TLS verification configuration handling."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from server import resolve_ssl_verification_setting
+
+
+class TestSSLVerificationSetting:
+    """Verify TLS verification configuration parsing."""
+
+    def test_default_verification_enabled(self):
+        """Defaults to strict verification when unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_ssl_verification_setting() is True
+
+    @pytest.mark.parametrize("env_value", ["true", "TRUE", "1", "yes", "on"])
+    def test_truthy_values_enable_verification(self, env_value):
+        """Truthy values keep verification enabled."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": env_value}, clear=True):
+            assert resolve_ssl_verification_setting() is True
+
+    @pytest.mark.parametrize("env_value", ["false", "FALSE", "0", "no", "off"])
+    def test_falsy_values_disable_verification(self, env_value):
+        """Falsy values disable verification."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": env_value}, clear=True):
+            assert resolve_ssl_verification_setting() is False
+
+    def test_ca_bundle_via_env(self, tmp_path):
+        """A CA bundle path is accepted via dedicated env variable."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": str(bundle_path)}, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_ca_bundle_with_whitespace_and_tilde(self, tmp_path):
+        """Whitespace and tilde-expansion are handled for CA bundle paths."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        env = {
+            "HOME": str(tmp_path),
+            "GERRIT_CA_BUNDLE": f" ~/{bundle_path.name} ",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_ca_bundle_via_ssl_verify_env(self, tmp_path):
+        """A filesystem path supplied in GERRIT_SSL_VERIFY is accepted."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": str(bundle_path)}, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_invalid_value_raises_error(self):
+        """Invalid configuration values raise an informative error."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": "maybe"}, clear=True):
+            with pytest.raises(ValueError):
+                resolve_ssl_verification_setting()
+
+    def test_missing_ca_bundle_path_raises_error(self):
+        """Missing CA bundle path leads to ValueError."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": "/non/existent/path.pem"}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "does not exist" in str(exc_info.value)
+
+    def test_ca_bundle_directory_path_raises_error(self, tmp_path):
+        """A CA bundle pointing to a directory is rejected."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": str(tmp_path)}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "does not exist" in str(exc_info.value)
+
+    def test_empty_ca_bundle_after_trim_raises_error(self):
+        """Whitespace-only CA bundle values are invalid."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": "   "}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "empty" in str(exc_info.value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Summary
      - allow Gerrit REST calls to honor GERRIT_SSL_VERIFY or a custom CA bundle
      - expose GERRIT_CA_BUNDLE and document both options for SAN-mismatched/self-signed certs
      - add regression tests for the new TLS configuration helper

     Background
      - our gerrit instance presents a self-signed certificate without SAN entries, so hostname validation fails even after installing it in local trust stores
      - developers across WSL/macOS/containers cannot easily modify trust stores or bypass SAN validation, so the MCP server must optionally skip verification or point at a custom bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable TLS verification for Gerrit connections: enable/disable verification or provide a custom CA bundle; accepts common truthy/falsy values, validates bundle paths, and emits clear warnings/errors.

* **Documentation**
  * README updated with environment variable examples, .env samples, troubleshooting notes, and a “Working with Self‑Signed Certificates” subsection describing temporary verification disabling and supplying a CA bundle.

* **Tests**
  * Added tests for defaults, truthy/falsy inputs, CA bundle handling, path validation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->