### PR TITLE
feat: allow posting review feedback to Gerrit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,40 @@ fetch_patchset_diff(change_id: str, base_patchset: str, target_patchset: str, fi
 - Analyze code modifications across patchset versions
 - Track evolution of changes through review iterations
 
+### Submit Review Feedback
+```python
+submit_gerrit_review(
+    change_id: str,
+    message: Optional[str] = None,
+    patchset_number: Optional[str] = None,
+    labels: Optional[Dict[str, int]] = None,
+    comments: Optional[List[Dict[str, Any]]] = None,
+    notify: str = "OWNER",
+)
+```
+- Post summary feedback, vote labels (e.g., `{"Code-Review": 1}`), and inline/file-level comments
+- Target a specific patchset or default to the latest revision
+- Control Gerrit's notification behaviour (`notify`: `NONE`, `OWNER`, `OWNER_REVIEWERS`, `ALL`)
+- Comment payloads accept dictionaries with `path`, `message`, and optional Gerrit comment fields (`line`, `side`, `range`, ...)
+
 ### Example Usage
 
 Review a complete change:
 ```python
 # Fetch latest patchset of change 23824
 change = fetch_gerrit_change("23824")
+```
+
+Submit review feedback with a vote and inline comment:
+```python
+submit_gerrit_review(
+    change_id="23824",
+    message="Looks good overall",
+    labels={"Code-Review": 1},
+    comments=[{"path": "src/app.py", "line": 42, "message": "Nice refactor."}],
+    patchset_number="2",           # optional: target a specific patchset
+    notify="OWNER_REVIEWERS",      # optional: adjust notification scope
+)
 ```
 
 Compare specific patchsets:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ export GERRIT_HOST="gerrit.example.com"  # Your Gerrit server hostname (without 
 export GERRIT_USER="your-username"       # Your Gerrit account username
 export GERRIT_HTTP_PASSWORD="your-http-password"  # Generated HTTP password from Gerrit Settings > HTTP Credentials
 export GERRIT_EXCLUDED_PATTERNS="\.pbxproj$,\.xcworkspace$,node_modules/"  # Optional: regex patterns for files to exclude from reviews
+# Optional TLS configuration for custom or self-signed certificates
+export GERRIT_SSL_VERIFY="true"              # Set to 'false' to skip TLS verification in constrained environments
+export GERRIT_CA_BUNDLE="/path/to/ca.pem"    # Optional custom CA bundle path used when verification stays enabled
+# Note: If both are set, GERRIT_CA_BUNDLE takes precedence and verification stays enabled using that bundle.
 ```
 
 Or create a `.env` file:
@@ -108,6 +112,9 @@ GERRIT_HOST=gerrit.example.com
 GERRIT_USER=your-username
 GERRIT_HTTP_PASSWORD=your-http-password
 GERRIT_EXCLUDED_PATTERNS=\.pbxproj$,\.xcworkspace$,node_modules/
+GERRIT_SSL_VERIFY=true
+GERRIT_CA_BUNDLE=/path/to/ca.pem
+# If both are set, the CA bundle wins.
 ```
 
 2. Generate HTTP password:
@@ -180,6 +187,12 @@ If you encounter connection issues:
 ### HTTP Credentials Authentication Issues
 
 If you're having trouble with authentication, check your Gerrit config for `gitBasicAuthPolicy = HTTP` (or `HTTP_LDAP`).
+
+### Working with Self-Signed Certificates
+
+- `GERRIT_SSL_VERIFY=false` disables TLS verification when Gerrit uses an internally issued certificate lacking required Subject Alternative Name (SAN) entries.
+- Provide a custom certificate bundle via `GERRIT_CA_BUNDLE=/path/to/ca.pem` to keep verification enabled while trusting a private CA.
+- Treat disabled verification as a temporary workaround until a certificate with matching SANs is issued for the Gerrit hostnames you access.
 
 ## License
 

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from urllib.parse import quote
+from pathlib import Path
 import requests
 
 from dotenv import load_dotenv
@@ -26,6 +27,48 @@ class GerritContext:
     host: str
     user: str
     http_password: Optional[str] = None
+    verify_ssl: Union[bool, str] = True
+
+
+def resolve_ssl_verification_setting() -> Union[bool, str]:
+    """Resolve SSL verification behaviour based on environment configuration."""
+    ssl_verify_env = os.getenv("GERRIT_SSL_VERIFY")
+    ca_bundle_env = os.getenv("GERRIT_CA_BUNDLE")
+
+    # Explicit CA bundle takes precedence when provided
+    if ca_bundle_env:
+        ca_bundle_clean = ca_bundle_env.strip()
+        if not ca_bundle_clean:
+            raise ValueError(
+                "GERRIT_CA_BUNDLE is set but empty after trimming whitespace. "
+                "Please provide a valid certificate bundle path or unset the variable."
+            )
+        ca_path = Path(ca_bundle_clean).expanduser()
+        if not (ca_path.exists() and ca_path.is_file()):
+            raise ValueError(
+                f"Configured GERRIT_CA_BUNDLE path '{ca_path}' does not exist. "
+                "Please provide a valid certificate bundle path or unset the variable."
+            )
+        return str(ca_path)
+
+    if ssl_verify_env is None:
+        return True
+
+    normalized_value = ssl_verify_env.strip().lower()
+    if normalized_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalized_value in {"0", "false", "no", "off"}:
+        logger.warning("TLS verification disabled via GERRIT_SSL_VERIFY. Use with caution.")
+        return False
+
+    # Allow specifying a direct CA bundle path via GERRIT_SSL_VERIFY
+    potential_path = Path(ssl_verify_env.strip()).expanduser()
+    if potential_path.exists() and potential_path.is_file():
+        return str(potential_path)
+
+    raise ValueError(
+        "Invalid GERRIT_SSL_VERIFY value. Provide true/false or a path to a CA bundle."
+    )
 
 def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
     """Make a REST API request to Gerrit and handle the response"""
@@ -49,7 +92,7 @@ def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
             'User-Agent': 'GerritReviewMCP/1.0'
         }
         
-        response = requests.get(url, auth=auth, headers=headers, verify=True)
+        response = requests.get(url, auth=auth, headers=headers, verify=gerrit_ctx.verify_ssl)
         
         if response.status_code == 401:
             raise Exception("Authentication failed. Please check your Gerrit HTTP password in your account settings.")
@@ -82,7 +125,8 @@ async def gerrit_lifespan(server: FastMCP) -> AsyncIterator[GerritContext]:
     
     # Log simple error if user includes protocol in GERRIT_HOST
     if host.startswith(('http://', 'https://')):
-        logger.error("GERRIT_HOST should not include protocol (http:// or https://). Use hostname only.")
+        logger.warning("GERRIT_HOST should not include protocol; stripping scheme.")
+        host = re.sub(r'^https?://', '', host).rstrip('/')
     
     if not all([host, user]):
         logger.error("Missing required environment variables:")
@@ -100,7 +144,9 @@ async def gerrit_lifespan(server: FastMCP) -> AsyncIterator[GerritContext]:
         logger.error(f"Password configuration error: {str(e)}")
         raise
 
-    ctx = GerritContext(host=host, user=user, http_password=password)
+    verify_ssl = resolve_ssl_verification_setting()
+
+    ctx = GerritContext(host=host, user=user, http_password=password, verify_ssl=verify_ssl)
     try:
         yield ctx
     finally:

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 import re
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, List
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
@@ -18,6 +18,8 @@ from config import create_auth_handler, get_password
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT = 30
 
 # Load environment variables
 load_dotenv()
@@ -70,7 +72,54 @@ def resolve_ssl_verification_setting() -> Union[bool, str]:
         "Invalid GERRIT_SSL_VERIFY value. Provide true/false or a path to a CA bundle."
     )
 
-def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
+
+def build_review_comments(comments: Optional[List[Dict[str, Any]]]) -> Dict[str, List[Dict[str, Any]]]:
+    """Convert a flat comment definition list into Gerrit's review payload structure."""
+    if not comments:
+        return {}
+
+    comment_map: Dict[str, List[Dict[str, Any]]] = {}
+
+    for index, comment in enumerate(comments, start=1):
+        if not isinstance(comment, dict):
+            raise ValueError(
+                f"Comment entry #{index} must be a mapping with 'path' and 'message' keys."
+            )
+
+        path = comment.get("path")
+        message = comment.get("message")
+
+        if not path or not isinstance(path, str):
+            raise ValueError(f"Comment entry #{index} is missing a valid 'path' value.")
+        if not message or not isinstance(message, str):
+            raise ValueError(f"Comment entry #{index} is missing a valid 'message'.")
+
+        # Remove path key but keep the remaining fields for Gerrit
+        payload_comment = {k: v for k, v in comment.items() if k != "path" and v is not None}
+        line_value = payload_comment.get("line")
+        if line_value is not None and (not isinstance(line_value, int) or line_value <= 0):
+            raise ValueError(
+                f"Comment entry #{index} has invalid 'line' value; must be a positive integer."
+            )
+        range_value = payload_comment.get("range")
+        if range_value is not None and not isinstance(range_value, dict):
+            raise ValueError(
+                f"Comment entry #{index} has invalid 'range' value; must be a mapping."
+            )
+        payload_comment.setdefault("message", message)
+
+        comment_map.setdefault(path, []).append(payload_comment)
+
+    return comment_map
+
+def make_gerrit_rest_request(
+    ctx: Context,
+    endpoint: str,
+    *,
+    method: str = "GET",
+    params: Optional[Dict[str, Any]] = None,
+    json_payload: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Make a REST API request to Gerrit and handle the response"""
     gerrit_ctx = ctx.request_context.lifespan_context
     
@@ -91,8 +140,17 @@ def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
             'Accept': 'application/json',
             'User-Agent': 'GerritReviewMCP/1.0'
         }
-        
-        response = requests.get(url, auth=auth, headers=headers, verify=gerrit_ctx.verify_ssl)
+
+        response = requests.request(
+            method,
+            url,
+            auth=auth,
+            headers=headers,
+            params=params,
+            json=json_payload,
+            verify=gerrit_ctx.verify_ssl,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
+        )
         
         if response.status_code == 401:
             raise Exception("Authentication failed. Please check your Gerrit HTTP password in your account settings.")
@@ -103,6 +161,9 @@ def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
         content = response.text
         if content.startswith(")]}'"):
             content = content[4:]
+        content = content.strip()
+        if not content:
+            return {}
             
         try:
             return json.loads(content)
@@ -112,8 +173,9 @@ def make_gerrit_rest_request(ctx: Context, endpoint: str) -> Dict[str, Any]:
             
     except requests.exceptions.RequestException as e:
         logger.error(f"REST request failed: {str(e)}")
-        if hasattr(e, 'response'):
-            logger.error(f"Response status: {e.response.status_code}")
+        response = getattr(e, "response", None)
+        if response is not None:
+            logger.error(f"Response status: {response.status_code}")
         raise Exception(f"Failed to make Gerrit REST API request: {str(e)}")
 
 
@@ -344,6 +406,70 @@ def fetch_patchset_diff(ctx: Context, change_id: str, base_patchset: str, target
         "base_patchset": base_patchset,
         "target_patchset": target_patchset,
         "files": changed_files
+    }
+
+
+@mcp.tool()
+def submit_gerrit_review(
+    ctx: Context,
+    change_id: str,
+    message: Optional[str] = None,
+    patchset_number: Optional[str] = None,
+    labels: Optional[Dict[str, int]] = None,
+    comments: Optional[List[Dict[str, Any]]] = None,
+    notify: str = "OWNER",
+) -> Dict[str, Any]:
+    """Submit a review message (and optional votes/comments) to Gerrit."""
+
+    if not any([message, labels, comments]):
+        raise ValueError("Review submission requires at least one of message, labels, or comments.")
+
+    change_endpoint = "a/changes/{change_id}/detail?o=ALL_REVISIONS".format(change_id=change_id)
+    change_info = make_gerrit_rest_request(ctx, change_endpoint)
+
+    revisions = change_info.get("revisions", {})
+    current_revision = change_info.get("current_revision")
+
+    target_revision = None
+    if patchset_number:
+        for revision_hash, info in revisions.items():
+            if str(info.get("_number")) == str(patchset_number):
+                target_revision = revision_hash
+                break
+        if not target_revision:
+            available = sorted(str(info.get("_number")) for info in revisions.values())
+            raise ValueError(
+                f"Patchset {patchset_number} not found. Available patchsets: {', '.join(available)}"
+            )
+    else:
+        target_revision = current_revision
+
+    if not target_revision:
+        raise ValueError("Unable to determine target revision for review submission.")
+
+    payload: Dict[str, Any] = {"notify": notify}
+
+    if message:
+        payload["message"] = message
+    if labels:
+        payload["labels"] = labels
+
+    structured_comments = build_review_comments(comments)
+    if structured_comments:
+        payload["comments"] = structured_comments
+
+    review_endpoint = f"a/changes/{change_id}/revisions/{target_revision}/review"
+    response = make_gerrit_rest_request(
+        ctx,
+        review_endpoint,
+        method="POST",
+        json_payload=payload,
+    )
+
+    return {
+        "change_id": change_id,
+        "revision": target_revision,
+        "submitted": response,
     }
 
 if __name__ == "__main__":

--- a/tests/test_ssl_config.py
+++ b/tests/test_ssl_config.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Unit tests for TLS verification configuration handling."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from server import resolve_ssl_verification_setting
+
+
+class TestSSLVerificationSetting:
+    """Verify TLS verification configuration parsing."""
+
+    def test_default_verification_enabled(self):
+        """Defaults to strict verification when unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_ssl_verification_setting() is True
+
+    @pytest.mark.parametrize("env_value", ["true", "TRUE", "1", "yes", "on"])
+    def test_truthy_values_enable_verification(self, env_value):
+        """Truthy values keep verification enabled."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": env_value}, clear=True):
+            assert resolve_ssl_verification_setting() is True
+
+    @pytest.mark.parametrize("env_value", ["false", "FALSE", "0", "no", "off"])
+    def test_falsy_values_disable_verification(self, env_value):
+        """Falsy values disable verification."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": env_value}, clear=True):
+            assert resolve_ssl_verification_setting() is False
+
+    def test_ca_bundle_via_env(self, tmp_path):
+        """A CA bundle path is accepted via dedicated env variable."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": str(bundle_path)}, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_ca_bundle_with_whitespace_and_tilde(self, tmp_path):
+        """Whitespace and tilde-expansion are handled for CA bundle paths."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        env = {
+            "HOME": str(tmp_path),
+            "GERRIT_CA_BUNDLE": f" ~/{bundle_path.name} ",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_ca_bundle_via_ssl_verify_env(self, tmp_path):
+        """A filesystem path supplied in GERRIT_SSL_VERIFY is accepted."""
+        bundle_path = tmp_path / "ca.pem"
+        bundle_path.write_text("certificate")
+
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": str(bundle_path)}, clear=True):
+            assert resolve_ssl_verification_setting() == str(bundle_path)
+
+    def test_invalid_value_raises_error(self):
+        """Invalid configuration values raise an informative error."""
+        with patch.dict(os.environ, {"GERRIT_SSL_VERIFY": "maybe"}, clear=True):
+            with pytest.raises(ValueError):
+                resolve_ssl_verification_setting()
+
+    def test_missing_ca_bundle_path_raises_error(self):
+        """Missing CA bundle path leads to ValueError."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": "/non/existent/path.pem"}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "does not exist" in str(exc_info.value)
+
+    def test_ca_bundle_directory_path_raises_error(self, tmp_path):
+        """A CA bundle pointing to a directory is rejected."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": str(tmp_path)}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "does not exist" in str(exc_info.value)
+
+    def test_empty_ca_bundle_after_trim_raises_error(self):
+        """Whitespace-only CA bundle values are invalid."""
+        with patch.dict(os.environ, {"GERRIT_CA_BUNDLE": "   "}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                resolve_ssl_verification_setting()
+            assert "empty" in str(exc_info.value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_submit_review.py
+++ b/tests/test_submit_review.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tests for review submission utilities."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from server import (
+    build_review_comments,
+    submit_gerrit_review,
+)
+
+
+class TestBuildReviewComments:
+    """Validate comment payload transformation logic."""
+
+    def test_empty_comments_returns_empty_mapping(self):
+        assert build_review_comments(None) == {}
+        assert build_review_comments([]) == {}
+
+    def test_comment_payload_structure(self):
+        comments = [
+            {"path": "a/file.py", "line": 12, "message": "Fix this"},
+            {"path": "a/file.py", "line": 18, "message": "Another"},
+            {"path": "b/file.py", "message": "File level"},
+        ]
+
+        expected = {
+            "a/file.py": [
+                {"line": 12, "message": "Fix this"},
+                {"line": 18, "message": "Another"},
+            ],
+            "b/file.py": [
+                {"message": "File level"},
+            ],
+        }
+
+        assert build_review_comments(comments) == expected
+
+    def test_invalid_comment_raises_value_error(self):
+        with pytest.raises(ValueError):
+            build_review_comments([{"message": "Missing path"}])
+
+    def test_invalid_line_value_raises_value_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            build_review_comments([
+                {"path": "file.py", "line": 0, "message": "Nope"}
+            ])
+        assert "line" in str(exc_info.value)
+
+    def test_invalid_range_value_raises_value_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            build_review_comments([
+                {"path": "file.py", "range": "oops", "message": "Nope"}
+            ])
+        assert "range" in str(exc_info.value)
+
+
+class TestSubmitGerritReview:
+    """Ensure review submissions are orchestrated correctly."""
+
+    def _dummy_ctx(self):
+        return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=None))
+
+    def test_submit_review_uses_current_revision(self, monkeypatch):
+        calls = []
+
+        def fake_make_request(ctx, endpoint, *, method="GET", params=None, json_payload=None):
+            calls.append((endpoint, method, json_payload))
+            if method == "GET":
+                return {
+                    "current_revision": "rev123",
+                    "revisions": {
+                        "rev123": {"_number": 1}
+                    },
+                }
+            return {"labels": {"Code-Review": 1}}
+
+        monkeypatch.setattr("server.make_gerrit_rest_request", fake_make_request)
+
+        result = submit_gerrit_review(
+            self._dummy_ctx(),
+            change_id="12345",
+            message="Looks good",
+            labels={"Code-Review": 1},
+            comments=[{"path": "a/file.py", "message": "Nice"}],
+        )
+
+        assert result["revision"] == "rev123"
+        assert len(calls) == 2
+        assert calls[1][1] == "POST"
+        assert calls[1][2]["labels"] == {"Code-Review": 1}
+
+    def test_submit_review_patchset_not_found(self, monkeypatch):
+        def fake_make_request(ctx, endpoint, *, method="GET", params=None, json_payload=None):
+            return {
+                "current_revision": "rev123",
+                "revisions": {
+                    "rev123": {"_number": 1}
+                },
+            }
+
+        monkeypatch.setattr("server.make_gerrit_rest_request", fake_make_request)
+
+        with pytest.raises(ValueError) as exc_info:
+            submit_gerrit_review(
+                self._dummy_ctx(),
+                change_id="12345",
+                patchset_number="999",
+                message="Test",
+            )
+
+        assert "Patchset 999 not found" in str(exc_info.value)
+
+    def test_submit_review_requires_payload(self):
+        with pytest.raises(ValueError):
+            submit_gerrit_review(self._dummy_ctx(), change_id="12345")
+
+    def test_submit_review_respects_notify(self, monkeypatch):
+        captured_payload = {}
+
+        def fake_make_request(ctx, endpoint, *, method="GET", params=None, json_payload=None):
+            if method == "GET":
+                return {
+                    "current_revision": "rev123",
+                    "revisions": {
+                        "rev123": {"_number": 1}
+                    },
+                }
+            captured_payload.update(json_payload or {})
+            return {}
+
+        monkeypatch.setattr("server.make_gerrit_rest_request", fake_make_request)
+
+        submit_gerrit_review(
+            self._dummy_ctx(),
+            change_id="12345",
+            message="Test",
+            notify="OWNER_REVIEWERS",
+        )
+
+        assert captured_payload.get("notify") == "OWNER_REVIEWERS"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Summary
      - add an MCP tool submit_gerrit_review to send summary messages, label votes, and inline/file-level comments
      - generalize the REST helper to support POST requests and structured payloads
      - extend docs with usage guidance and add unit tests for comment shaping and review submission flow

     Testing
      - python -m pytest (fails only in docker integration tests because this environment cannot run docker; all other tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit reviews with custom messages, votes, and inline comments on specific patchsets.
  * Control notification scope when submitting reviews.
  * Configurable request timeouts and enhanced SSL verification for secure communications.

* **Documentation**
  * Added "Submit Review Feedback" guide with detailed usage examples and payload structure documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->